### PR TITLE
Put latex compilation errors onto the pdf page

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,12 @@ Then
 ```sh
 pip install freemind-latex
 ```
+
+
+## Testing
+
+```sh
+virtualenv testenv
+source testenv/bin/activate
+pip install --upgrade . && python -m pytest tests/
+```

--- a/src/freemindlatex/convert.py
+++ b/src/freemindlatex/convert.py
@@ -89,6 +89,12 @@ class Node(object):
   def __init__(self, dom_node, level=0):
     self.type = dom_node.nodeName
     self.level = level
+
+    try:
+      self.nodeid = dom_node.attributes['ID'].value
+    except:
+      self.nodeid = "NONE"
+
     try:
       self.text = dom_node.attributes['TEXT'].value
     except:
@@ -343,6 +349,22 @@ class Organization(object):
   def SaveFromDom(self, dom):
     return Node(dom.childNodes[0])
 
+  def _TraverseAllDescendents(self, node=None):
+    """An iterator to yield all the descendents in a DFS manner
+
+    Args:
+      node: the current node. When it is none, will start from the root.
+
+    Returns:
+      An iterator of all descendents, including itself.
+    """
+    if node is None:
+      node = self.doc
+    yield node
+    for child in node.children:
+      for grand_kid in self._TraverseAllDescendents(child):
+        yield grand_kid
+
   def LabelAllIntoLayers(self, node):
     formatting_node = node.GetTheFormattingChildNode()
     if formatting_node is not None:
@@ -402,7 +424,11 @@ class Organization(object):
       node_error_mapping: mappings between frames' corresponding
         node IDs and the error they produce.
     """
-    pass
+    for node in self._TraverseAllDescendents():
+      if node.nodeid in node_error_mapping:
+        node.SetPrintingFunc(
+          OutputFrameAndDebugMessage(
+            node, node_error_mapping[node.nodeid]))
 
   def OutputToHTML(self, filename):
     with codecs.open(filename, 'w', 'utf8') as outputfile:
@@ -702,6 +728,7 @@ def OutputParagraph(current_node):
       PrintInBeamerLatexFormat(writer)
 
   def PrintInBeamerLatexFormat(writer):
+    writer.write("\n%%frame: {}%%\n".format(current_node.nodeid))
     writer.write(r'\begin{frame}{')
     current_node.PrintSelfToWriter(writer, 'beamer_latex')
     writer.write(r'}')
@@ -759,19 +786,37 @@ def DirectlyPrintSub(current_node):
   return PrintTo
 
 
-def OutputFrameAndDebugMessage(current_node, error_message):
+def OutputFrameAndDebugMessage(current_node, error_messages):
   """Output the error message as title, and normal content as content.
 
   This printer is used when there is an error on this page.
 
   Args:
     current_node: the current node (a frame).
-    error_message: the latex compilation message for errors in this frame.
+    error_messages: a list of latex compilation messages for errors in this frame.
 
   Returns:
     A printer for printing the latex code into a writer.
   """
-  pass
+
+  def PrintTo(writer, format='beamer_latex'):
+    if format == 'beamer_latex':
+      PrintInBeamerLatexFormat(writer)
+    else:
+      logging.fatal("Unsupported format %s", format)
+
+  def PrintInBeamerLatexFormat(writer):
+    writer.write(r'\begin{frame}[fragile]{Error on page\ldots}')
+    writer.write(r'\begin{verbatim}')
+    writer.write('\n')
+    for msg in error_messages:
+      writer.write(msg)
+      writer.write("\n")
+    writer.write(r'\end{verbatim}')
+    writer.write('\n')
+    writer.write(r'\end{frame}')
+
+  return PrintTo
 
 
 def DirectlyPrintThisAndSub(current_node):

--- a/src/freemindlatex/convert.py
+++ b/src/freemindlatex/convert.py
@@ -392,6 +392,18 @@ class Organization(object):
     self.LabelAllIntoLayers(node)
     node.SetPrintingFunc(DirectlyPrintSub(node))
 
+  def LabelErrorsOnFrames(self, node_error_mapping):
+    """Label frames in the graph to output error messages instead.
+
+    It will label the frame in a way to print its contents as they are,
+    with the error message on the title.
+
+    Args:
+      node_error_mapping: mappings between frames' corresponding
+        node IDs and the error they produce.
+    """
+    pass
+
   def OutputToHTML(self, filename):
     with codecs.open(filename, 'w', 'utf8') as outputfile:
       print >> outputfile, """
@@ -745,6 +757,21 @@ def DirectlyPrintSub(current_node):
       writer.write('\n')
 
   return PrintTo
+
+
+def OutputFrameAndDebugMessage(current_node, error_message):
+  """Output the error message as title, and normal content as content.
+
+  This printer is used when there is an error on this page.
+
+  Args:
+    current_node: the current node (a frame).
+    error_message: the latex compilation message for errors in this frame.
+
+  Returns:
+    A printer for printing the latex code into a writer.
+  """
+  pass
 
 
 def DirectlyPrintThisAndSub(current_node):

--- a/static_files/slides.tex
+++ b/static_files/slides.tex
@@ -5,6 +5,7 @@
 %%\usepackage{beamerthemeclassic}
 \usepackage[utf8x]{inputenc}
 \usepackage{CJK}
+\usepackage{verbatim}
 \usepackage{todonotes}
 \presetkeys{todonotes}{inline}{}
 

--- a/tests/test_on_mm_files.py
+++ b/tests/test_on_mm_files.py
@@ -86,6 +86,8 @@ class TestHandlingErrors(BaseTest):
           self._test_dir,
           "latex.log")).read())
 
+    self._AssertErrorOnSecondPage("Missing $ inserted")
+
   @timeout_decorator.timeout(5)
   def testOnFourLayersOfNestedEnums(self):
     """Latex does not support multi-layered enums.

--- a/tests/test_on_mm_files.py
+++ b/tests/test_on_mm_files.py
@@ -10,8 +10,9 @@ import timeout_decorator
 from freemindlatex import __main__
 
 
-class TestBasicUsecase(unittest.TestCase):
-  """Our program compiles in working directories."""
+class BaseTest(unittest.TestCase):
+  """Base test that setups the directory for testing at self._test_dir
+  """
 
   def setUp(self):
     self._test_dir = tempfile.mkdtemp()
@@ -19,6 +20,10 @@ class TestBasicUsecase(unittest.TestCase):
 
   def tearDown(self):
     shutil.rmtree(self._test_dir)
+
+
+class TestBasicUsecase(BaseTest):
+  """Our program compiles in working directories."""
 
   def testCompilingInitialDirectory(self):
     """In a new directory, we will prepare an empty content to start with."""
@@ -33,9 +38,26 @@ class TestBasicUsecase(unittest.TestCase):
     self.assertEquals(4, pdf_file.getNumPages())
     self.assertIn("Author", pdf_file.getPage(0).extractText())
 
+
+class TestHandlingErrors(BaseTest):
+
+  def _AssertErrorOnSecondPage(self, error_msg):
+    slides_file_loc = os.path.join(self._test_dir, "slides.pdf")
+    self.assertTrue(os.path.exists(slides_file_loc))
+    pdf_file = PyPDF2.PdfFileReader(open(slides_file_loc, "rb"))
+
+    self.assertEquals(4, pdf_file.getNumPages())
+
+    # Error message should appear on the 2nd page
+    self.asertIn(error_msg, pdf_file.getPage(0).extractText())
+
+    # Other pages should remain intact
+    self.assertIn("Author", pdf_file.getPage(0).extractText())
+    self.assertIn("Second Slide", pdf_file.getPage(2).extractText())
+
   @timeout_decorator.timeout(5)
-  def testDoesNotLingerOnMissingDollarSign(self):
-    """When there is a missing dollar sign, finish compilation and produce logs."""
+  def testOnMissingDollarSign(self):
+    """Missing dollar sign causes Latex to error."""
     __main__.InitDir(self._test_dir)
     shutil.copy("tests/data/additional_dollar.mm",
                 os.path.join(self._test_dir, "mindmap.mm"))
@@ -48,8 +70,9 @@ class TestBasicUsecase(unittest.TestCase):
           "latex.log")).read())
 
   @timeout_decorator.timeout(5)
-  def testDoesNotLingerOnFourLayersOfNestedEnums(self):
-    """Latex does not support multi-layered enums"""
+  def testOnFourLayersOfNestedEnums(self):
+    """Latex does not support multi-layered enums.
+    """
     __main__.InitDir(self._test_dir)
     shutil.copy("tests/data/multi_layered_enums.mm",
                 os.path.join(self._test_dir, "mindmap.mm"))
@@ -61,6 +84,7 @@ class TestBasicUsecase(unittest.TestCase):
           self._test_dir,
           "latex.log")).read())
 
+    self._AssertErrorOnSecondPage("Too deeply nested")
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/test_on_mm_files.py
+++ b/tests/test_on_mm_files.py
@@ -10,8 +10,9 @@ import timeout_decorator
 from freemindlatex import __main__
 
 
-class TestBasicUsecase(unittest.TestCase):
-  """Our program compiles in working directories."""
+class BaseTest(unittest.TestCase):
+  """Base test that setups the directory for testing at self._test_dir
+  """
 
   def setUp(self):
     self._test_dir = tempfile.mkdtemp()
@@ -19,6 +20,10 @@ class TestBasicUsecase(unittest.TestCase):
 
   def tearDown(self):
     shutil.rmtree(self._test_dir)
+
+
+class TestBasicUsecase(BaseTest):
+  """Our program compiles in working directories."""
 
   def testCompilingInitialDirectory(self):
     """In a new directory, we will prepare an empty content to start with."""
@@ -31,25 +36,46 @@ class TestBasicUsecase(unittest.TestCase):
     self.assertEquals(4, pdf_file.getNumPages())
     self.assertIn("Author", pdf_file.getPage(0).extractText())
 
+
+class TestHandlingErrors(BaseTest):
+
+  def _AssertErrorOnSecondPage(self, error_msg):
+    slides_file_loc = os.path.join(self._test_dir, "slides.pdf")
+    self.assertTrue(os.path.exists(slides_file_loc))
+    pdf_file = PyPDF2.PdfFileReader(open(slides_file_loc, "rb"))
+
+    self.assertEquals(4, pdf_file.getNumPages())
+
+    # Error message should appear on the 2nd page
+    self.asertIn(error_msg, pdf_file.getPage(0).extractText())
+
+    # Other pages should remain intact
+    self.assertIn("Author", pdf_file.getPage(0).extractText())
+    self.assertIn("Second Slide", pdf_file.getPage(2).extractText())
+
+
   @timeout_decorator.timeout(5)
-  def testDoesNotLingerOnMissingDollarSign(self):
-    """When there is a missing dollar sign, finish compilation and produce logs."""
+  def testOnMissingDollarSign(self):
+    """Missing dollar sign causes Latex to error."""
     __main__.InitDir(self._test_dir)
     shutil.copy("tests/data/additional_dollar.mm",
                 os.path.join(self._test_dir, "mindmap.mm"))
     self.assertRaises(__main__.LatexCompilationError, __main__.CompileDir,
                       self._test_dir)
+    self._AssertErrorOnSecondPage("Missing $ inserted.")
 
 
   @timeout_decorator.timeout(5)
-  def testDoesNotLingerOnFourLayersOfNestedEnums(self):
-    """Latex does not support multi-layered enums"""
+  def testOnFourLayersOfNestedEnums(self):
+    """Latex does not support multi-layered enums.
+    """
     __main__.InitDir(self._test_dir)
     shutil.copy("tests/data/multi_layered_enums.mm",
                 os.path.join(self._test_dir, "mindmap.mm"))
     self.assertRaises(__main__.LatexCompilationError, __main__.CompileDir,
                       self._test_dir)
 
+    self._AssertErrorOnSecondPage("Too deeply nested")
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/test_on_mm_files.py
+++ b/tests/test_on_mm_files.py
@@ -66,11 +66,16 @@ class TestHandlingErrors(BaseTest):
     self.assertEquals(4, pdf_file.getNumPages())
 
     # Error message should appear on the 2nd page
-    self.asertIn(error_msg, pdf_file.getPage(0).extractText())
+    # Note that the extracted text don't have spaces, so I have to trim the
+    # spaces
+    self.assertIn(
+      "".join(
+        error_msg.split()),
+      pdf_file.getPage(1).extractText())
 
     # Other pages should remain intact
     self.assertIn("Author", pdf_file.getPage(0).extractText())
-    self.assertIn("Second Slide", pdf_file.getPage(2).extractText())
+    self.assertIn("Secondslide", pdf_file.getPage(2).extractText())
 
   @timeout_decorator.timeout(5)
   def testOnMissingDollarSign(self):
@@ -78,6 +83,7 @@ class TestHandlingErrors(BaseTest):
     __main__.InitDir(self._test_dir)
     shutil.copy("tests/data/additional_dollar.mm",
                 os.path.join(self._test_dir, "mindmap.mm"))
+
     self.assertFalse(__main__.CompileDir(self._test_dir))
     self.assertIn(
       "Missing $ inserted",


### PR DESCRIPTION
Previously latex compilation errors only show in the logs. Now we make it available in the pdf page. We show "error on page..." and then the error message in the page content.

Tested:
  Assertions on the error page test cases.